### PR TITLE
feat: implement GET /api/users/current endpoint

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -41,3 +41,18 @@ export const usersRoute = new Elysia({ prefix: '/api/users' })
       }),
     }
   )
+  .get('/current', async ({ headers, set }) => {
+    try {
+      const authHeader = headers['authorization']
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        set.status = 401
+        return { error: 'Unauthorized' }
+      }
+
+      const token = authHeader.replace('Bearer ', '')
+      return await usersService.getCurrentUser(token)
+    } catch (error: any) {
+      set.status = 401
+      return { error: 'Unauthorized' }
+    }
+  })

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -61,4 +61,25 @@ export const usersService = {
 
     return { data: token }
   },
+
+  async getCurrentUser(token: string) {
+    // 1. Find session and join with users table
+    const [result] = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        createdAt: users.createdAt,
+      })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(eq(sessions.token, token))
+      .limit(1)
+
+    if (!result) {
+      throw new Error('Unauthorized')
+    }
+
+    return { data: result }
+  },
 }


### PR DESCRIPTION
Implement endpoint to get the currently logged-in user based on Bearer token (Issue #8). Includes service logic and route definition.