### PR TITLE
feat: implement DELETE /api/users/logout endpoint

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -41,16 +41,34 @@ export const usersRoute = new Elysia({ prefix: '/api/users' })
       }),
     }
   )
-  .get('/current', async ({ headers, set }) => {
-    try {
-      const authHeader = headers['authorization']
-      if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        set.status = 401
-        return { error: 'Unauthorized' }
-      }
+  .derive(({ headers }) => {
+    const authHeader = headers['authorization']
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return { token: null }
+    }
+    return { token: authHeader.replace('Bearer ', '') }
+  })
+  .get('/current', async ({ token, set }) => {
+    if (!token) {
+      set.status = 401
+      return { error: 'Unauthorized' }
+    }
 
-      const token = authHeader.replace('Bearer ', '')
+    try {
       return await usersService.getCurrentUser(token)
+    } catch (error: any) {
+      set.status = 401
+      return { error: 'Unauthorized' }
+    }
+  })
+  .delete('/logout', async ({ token, set }) => {
+    if (!token) {
+      set.status = 401
+      return { error: 'Unauthorized' }
+    }
+
+    try {
+      return await usersService.logoutUser(token)
     } catch (error: any) {
       set.status = 401
       return { error: 'Unauthorized' }

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -82,4 +82,15 @@ export const usersService = {
 
     return { data: result }
   },
+
+  async logoutUser(token: string) {
+    // 1. Delete session from database
+    const [result]: any = await db.delete(sessions).where(eq(sessions.token, token))
+
+    if (result.affectedRows === 0) {
+      throw new Error('Unauthorized')
+    }
+
+    return { data: 'OK' }
+  },
 }


### PR DESCRIPTION
Implement logout functionality by deleting session tokens from the database (Issue #10). Verification confirmed that tokens are invalidated after logout.